### PR TITLE
Update README.md: predictedState

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ let previousCorrected = null;
 const results = [];
 
 observations.forEach(observation => {
-	const predictedState = kFilter.predict({
+	const predicted = kFilter.predict({
 		previousCorrected
 	});
 
@@ -644,7 +644,7 @@ let previousCorrected = null;
 const results = [];
 
 observations.forEach(observation => {
-	const predictedState = kFilter.predict({
+	const predicted = kFilter.predict({
 		previousCorrected
 	});
 


### PR DESCRIPTION
This changes examples which use variable name `predictedState` to `predicted` which is the variable name used later in examples.

I discovered this independently, but was also mentioned here: https://github.com/piercus/kalman-filter/issues/47

Side note: are you willing to help me understand where I am going wrong or clear up my lack of understanding with using this library for online sensor fusion?  I'm happy to add an example to docs if I can get this figured out.

Thanks in advance!

Note: I accidentally submitted PR with my work account; apologies if it seems too mysterious.
Here's the public me: https://github.com/crosshj.  I'm happy to re-submit with my public account.